### PR TITLE
Add WHITE redaction colour

### DIFF
--- a/marisol/marisol.py
+++ b/marisol/marisol.py
@@ -20,6 +20,7 @@ class Area(Enum):
 class RedactionStyle(Enum):
     SOLID = ((0, 0, 0), (0, 0, 0), (1, 1, 1))
     OUTLINE = ((0, 0, 0), (1, 1, 1), (0, 0, 0))
+    WHITE = ((1, 1, 1), (1, 1, 1), (1, 1, 1))
 
     def __init__(self, stroke, fill, text):
         self.stroke = stroke


### PR DESCRIPTION
Redactions are generally black in colour. But I propose adding white, as digital documents are often exported as PDFs rather than just scanned. For those, white is a sometimes more preferable colour for redactions.